### PR TITLE
feat: CachekitIO backend full parity (session, metrics, SSRF, locking, TTL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # stable
         with:
+          toolchain: stable
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,16 @@ jobs:
           - rust: beta
             os: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # stable
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
       - name: Cache cargo registry
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Check formatting
         if: matrix.rust != '1.85'
@@ -55,15 +55,15 @@ jobs:
     name: wasm32 compilation check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # stable
         with:
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo registry
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Check wasm32 build
         run: cargo check -p cachekit-rs --target wasm32-unknown-unknown --features workers,encryption --no-default-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@e6bbaada0dce03cba6c8c531ef49f15965adc8ab # v2
         id: app-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@c3fc4de07084f75a2b61a5b933069bda6edf3d5c # v4
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -32,13 +32,13 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # stable
 
       - name: Cache cargo registry
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run tests before publish
         run: cargo test --features "cachekitio,redis,encryption,l1,macros"

--- a/crates/cachekit/Cargo.toml
+++ b/crates/cachekit/Cargo.toml
@@ -33,7 +33,7 @@ zeroize = { version = "1", features = ["derive"] }
 urlencoding = "2"
 hex = "0.4"
 url = "2"
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["v4", "js"] }
 
 # Optional: HTTP backend (native)
 reqwest = { version = "0.12", optional = true, default-features = false, features = ["rustls-tls", "json"] }

--- a/crates/cachekit/Cargo.toml
+++ b/crates/cachekit/Cargo.toml
@@ -12,7 +12,7 @@ name = "cachekit"
 
 [features]
 default = ["cachekitio", "encryption", "l1"]
-cachekitio = ["dep:reqwest"]
+cachekitio = ["dep:reqwest", "dep:serde_json"]
 redis = ["dep:fred"]
 workers = ["dep:worker", "dep:js-sys", "dep:getrandom"]
 # cachekit-core 0.2 folds aes-gcm into the `encryption` feature automatically on wasm32.
@@ -32,9 +32,12 @@ bytes = "1"
 zeroize = { version = "1", features = ["derive"] }
 urlencoding = "2"
 hex = "0.4"
+url = "2"
+uuid = { version = "1", features = ["v4"] }
 
 # Optional: HTTP backend (native)
-reqwest = { version = "0.12", optional = true, default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12", optional = true, default-features = false, features = ["rustls-tls", "json"] }
+serde_json = { version = "1", optional = true }
 
 # Optional: Redis backend
 fred = { version = "9", optional = true }

--- a/crates/cachekit/src/backend/cachekitio.rs
+++ b/crates/cachekit/src/backend/cachekitio.rs
@@ -6,6 +6,9 @@ use zeroize::Zeroizing;
 
 use crate::backend::{Backend, HealthStatus};
 use crate::error::{BackendError, BackendErrorKind};
+use crate::metrics::{metrics_headers, MetricsProvider};
+use crate::session::session_headers;
+use crate::url_validator::validate_cachekitio_url;
 
 // ── CachekitIO ────────────────────────────────────────────────────────────────
 
@@ -14,6 +17,7 @@ pub struct CachekitIO {
     client: reqwest::Client,
     api_key: Zeroizing<String>,
     api_url: String,
+    metrics_provider: Option<MetricsProvider>,
 }
 
 /// Redact `api_key` from debug output.
@@ -37,6 +41,21 @@ impl CachekitIO {
         &self.api_url
     }
 
+    /// Return a reference to the underlying HTTP client.
+    pub(crate) fn client(&self) -> &reqwest::Client {
+        &self.client
+    }
+
+    /// Return the API key as a string slice (for bearer auth in sibling modules).
+    pub(crate) fn api_key_str(&self) -> &str {
+        self.api_key.as_str()
+    }
+
+    /// Return a reference to the optional metrics provider (for sibling modules).
+    pub(crate) fn metrics_provider(&self) -> Option<&MetricsProvider> {
+        self.metrics_provider.as_ref()
+    }
+
     /// Build the full URL for a cache key path segment.
     ///
     /// Keys are percent-encoded so that slashes or special characters in the
@@ -52,14 +71,14 @@ impl CachekitIO {
 
     /// Build the health-check URL.
     fn health_url(&self) -> String {
-        format!("{}/v1/health", self.api_url.trim_end_matches('/'))
+        format!("{}/v1/cache/health", self.api_url.trim_end_matches('/'))
     }
 }
 
 // ── Error helpers ────────────────────────────────────────────────────────────
 
-/// Convert a reqwest error into a BackendError, preserving the source.
-fn reqwest_err(e: reqwest::Error) -> BackendError {
+/// Convert a reqwest error into a BackendError, sanitizing the API key from the message.
+pub(crate) fn reqwest_err_sanitized(e: reqwest::Error, api_key: &str) -> BackendError {
     let kind = if e.is_timeout() {
         BackendErrorKind::Timeout
     } else {
@@ -67,9 +86,22 @@ fn reqwest_err(e: reqwest::Error) -> BackendError {
     };
     BackendError {
         kind,
-        message: e.to_string(),
+        message: BackendError::sanitize_message(&e.to_string(), api_key),
         source: Some(Box::new(e)),
     }
+}
+
+/// Build a [`BackendError`] from an HTTP status + body, sanitizing the API key from output.
+pub(crate) fn from_http_status_sanitized(
+    status: u16,
+    body: &[u8],
+    api_key: &str,
+) -> BackendError {
+    let sanitized = BackendError::sanitize_message(
+        std::str::from_utf8(body).unwrap_or(""),
+        api_key,
+    );
+    BackendError::from_http_status(status, sanitized.as_bytes())
 }
 
 // ── Backend impl ──────────────────────────────────────────────────────────────
@@ -78,23 +110,39 @@ fn reqwest_err(e: reqwest::Error) -> BackendError {
 #[async_trait]
 impl Backend for CachekitIO {
     async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, BackendError> {
-        let resp = self
+        let mut req = self
             .client
             .get(self.url(key))
-            .bearer_auth(self.api_key.as_str())
+            .bearer_auth(self.api_key.as_str());
+
+        for (name, value) in session_headers() {
+            req = req.header(name, value);
+        }
+        for (name, value) in metrics_headers(self.metrics_provider.as_ref()) {
+            req = req.header(name, value);
+        }
+
+        let resp = req
             .send()
             .await
-            .map_err(reqwest_err)?;
+            .map_err(|e| reqwest_err_sanitized(e, self.api_key.as_str()))?;
 
         match resp.status().as_u16() {
             200 => {
-                let bytes = resp.bytes().await.map_err(reqwest_err)?;
+                let bytes = resp
+                    .bytes()
+                    .await
+                    .map_err(|e| reqwest_err_sanitized(e, self.api_key.as_str()))?;
                 Ok(Some(bytes.to_vec()))
             }
             404 => Ok(None),
             status => {
                 let body = resp.bytes().await.unwrap_or_default();
-                Err(BackendError::from_http_status(status, &body))
+                let sanitized = BackendError::sanitize_message(
+                    std::str::from_utf8(&body).unwrap_or(""),
+                    self.api_key.as_str(),
+                );
+                Err(BackendError::from_http_status(status, sanitized.as_bytes()))
             }
         }
     }
@@ -113,47 +161,83 @@ impl Backend for CachekitIO {
             .body(value);
 
         if let Some(ttl) = ttl {
-            req = req.header("X-Cache-TTL", ttl.as_secs().to_string());
+            req = req.header("X-TTL", ttl.as_secs().to_string());
         }
 
-        let resp = req.send().await.map_err(reqwest_err)?;
+        for (name, value) in session_headers() {
+            req = req.header(name, value);
+        }
+        for (name, value) in metrics_headers(self.metrics_provider.as_ref()) {
+            req = req.header(name, value);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| reqwest_err_sanitized(e, self.api_key.as_str()))?;
 
         let status = resp.status().as_u16();
         if (200..300).contains(&status) {
             Ok(())
         } else {
             let body = resp.bytes().await.unwrap_or_default();
-            Err(BackendError::from_http_status(status, &body))
+            let sanitized = BackendError::sanitize_message(
+                std::str::from_utf8(&body).unwrap_or(""),
+                self.api_key.as_str(),
+            );
+            Err(BackendError::from_http_status(status, sanitized.as_bytes()))
         }
     }
 
     async fn delete(&self, key: &str) -> Result<bool, BackendError> {
-        let resp = self
+        let mut req = self
             .client
             .delete(self.url(key))
-            .bearer_auth(self.api_key.as_str())
+            .bearer_auth(self.api_key.as_str());
+
+        for (name, value) in session_headers() {
+            req = req.header(name, value);
+        }
+        for (name, value) in metrics_headers(self.metrics_provider.as_ref()) {
+            req = req.header(name, value);
+        }
+
+        let resp = req
             .send()
             .await
-            .map_err(reqwest_err)?;
+            .map_err(|e| reqwest_err_sanitized(e, self.api_key.as_str()))?;
 
         match resp.status().as_u16() {
             200 | 204 => Ok(true),
             404 => Ok(false),
             status => {
                 let body = resp.bytes().await.unwrap_or_default();
-                Err(BackendError::from_http_status(status, &body))
+                let sanitized = BackendError::sanitize_message(
+                    std::str::from_utf8(&body).unwrap_or(""),
+                    self.api_key.as_str(),
+                );
+                Err(BackendError::from_http_status(status, sanitized.as_bytes()))
             }
         }
     }
 
     async fn exists(&self, key: &str) -> Result<bool, BackendError> {
-        let resp = self
+        let mut req = self
             .client
             .head(self.url(key))
-            .bearer_auth(self.api_key.as_str())
+            .bearer_auth(self.api_key.as_str());
+
+        for (name, value) in session_headers() {
+            req = req.header(name, value);
+        }
+        for (name, value) in metrics_headers(self.metrics_provider.as_ref()) {
+            req = req.header(name, value);
+        }
+
+        let resp = req
             .send()
             .await
-            .map_err(reqwest_err)?;
+            .map_err(|e| reqwest_err_sanitized(e, self.api_key.as_str()))?;
 
         match resp.status().as_u16() {
             200 => Ok(true),
@@ -165,13 +249,22 @@ impl Backend for CachekitIO {
     async fn health(&self) -> Result<HealthStatus, BackendError> {
         let start = std::time::Instant::now();
 
-        let resp = self
+        let mut req = self
             .client
             .get(self.health_url())
-            .bearer_auth(self.api_key.as_str())
+            .bearer_auth(self.api_key.as_str());
+
+        for (name, value) in session_headers() {
+            req = req.header(name, value);
+        }
+        for (name, value) in metrics_headers(self.metrics_provider.as_ref()) {
+            req = req.header(name, value);
+        }
+
+        let resp = req
             .send()
             .await
-            .map_err(reqwest_err)?;
+            .map_err(|e| reqwest_err_sanitized(e, self.api_key.as_str()))?;
 
         let latency = start.elapsed();
         let status = resp.status().as_u16();
@@ -187,7 +280,11 @@ impl Backend for CachekitIO {
             })
         } else {
             let body = resp.bytes().await.unwrap_or_default();
-            Err(BackendError::from_http_status(status, &body))
+            let sanitized = BackendError::sanitize_message(
+                std::str::from_utf8(&body).unwrap_or(""),
+                self.api_key.as_str(),
+            );
+            Err(BackendError::from_http_status(status, sanitized.as_bytes()))
         }
     }
 }
@@ -199,6 +296,8 @@ impl Backend for CachekitIO {
 pub struct CachekitIOBuilder {
     api_key: Option<Zeroizing<String>>,
     api_url: Option<String>,
+    allow_custom_host: bool,
+    metrics_provider: Option<MetricsProvider>,
 }
 
 impl CachekitIOBuilder {
@@ -214,6 +313,18 @@ impl CachekitIOBuilder {
         self
     }
 
+    /// Allow non-standard hostnames (e.g. custom proxies). Private IPs are still blocked.
+    pub fn allow_custom_host(mut self, allow: bool) -> Self {
+        self.allow_custom_host = allow;
+        self
+    }
+
+    /// Provide L1 cache metrics for request telemetry headers.
+    pub fn metrics_provider(mut self, provider: MetricsProvider) -> Self {
+        self.metrics_provider = Some(provider);
+        self
+    }
+
     /// Consume the builder and construct a [`CachekitIO`].
     ///
     /// # Errors
@@ -221,6 +332,7 @@ impl CachekitIOBuilder {
     /// Returns an error if:
     /// - `api_key` was not set.
     /// - the resolved URL scheme is not `https`.
+    /// - the URL hostname is not permitted (see [`validate_cachekitio_url`]).
     pub fn build(self) -> Result<CachekitIO, crate::error::CachekitError> {
         use crate::error::CachekitError;
 
@@ -228,19 +340,13 @@ impl CachekitIOBuilder {
             .api_key
             .filter(|k| !k.is_empty())
             .ok_or_else(|| CachekitError::Config("api_key is required".to_string()))?;
-        // api_key is already Zeroizing<String> from the builder — no re-wrapping needed.
 
         let api_url = self
             .api_url
             .unwrap_or_else(|| "https://api.cachekit.io".to_string());
 
-        // Enforce HTTPS — plaintext HTTP must never transmit API keys or cached data.
-        if !api_url.starts_with("https://") {
-            return Err(CachekitError::Config(format!(
-                "api_url must use HTTPS, got: {}",
-                api_url
-            )));
-        }
+        // Validate URL: HTTPS, allowed host, no private IPs.
+        validate_cachekitio_url(&api_url, self.allow_custom_host)?;
 
         let client = reqwest::Client::builder()
             .use_rustls_tls()
@@ -253,6 +359,7 @@ impl CachekitIOBuilder {
             client,
             api_key,
             api_url,
+            metrics_provider: self.metrics_provider,
         })
     }
 }

--- a/crates/cachekit/src/backend/cachekitio.rs
+++ b/crates/cachekit/src/backend/cachekitio.rs
@@ -92,15 +92,9 @@ pub(crate) fn reqwest_err_sanitized(e: reqwest::Error, api_key: &str) -> Backend
 }
 
 /// Build a [`BackendError`] from an HTTP status + body, sanitizing the API key from output.
-pub(crate) fn from_http_status_sanitized(
-    status: u16,
-    body: &[u8],
-    api_key: &str,
-) -> BackendError {
-    let sanitized = BackendError::sanitize_message(
-        std::str::from_utf8(body).unwrap_or(""),
-        api_key,
-    );
+pub(crate) fn from_http_status_sanitized(status: u16, body: &[u8], api_key: &str) -> BackendError {
+    let sanitized =
+        BackendError::sanitize_message(std::str::from_utf8(body).unwrap_or(""), api_key);
     BackendError::from_http_status(status, sanitized.as_bytes())
 }
 

--- a/crates/cachekit/src/backend/cachekitio_lock.rs
+++ b/crates/cachekit/src/backend/cachekitio_lock.rs
@@ -1,0 +1,128 @@
+//! [`LockableBackend`] implementation for the cachekit.io HTTP backend.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use super::cachekitio::{from_http_status_sanitized, reqwest_err_sanitized, CachekitIO};
+use super::LockableBackend;
+use crate::error::BackendError;
+
+#[derive(Serialize)]
+struct LockAcquireRequest {
+    timeout_ms: u64,
+}
+
+#[derive(Deserialize)]
+struct LockAcquireResponse {
+    lock_id: Option<String>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[async_trait]
+impl LockableBackend for CachekitIO {
+    async fn acquire_lock(
+        &self,
+        key: &str,
+        timeout_ms: u64,
+    ) -> Result<Option<String>, BackendError> {
+        let url = format!(
+            "{}/v1/cache/{}/lock",
+            self.api_url().trim_end_matches('/'),
+            urlencoding::encode(key)
+        );
+
+        let body = serde_json::to_vec(&LockAcquireRequest { timeout_ms }).map_err(|e| {
+            BackendError::permanent(format!("failed to serialize lock request: {e}"))
+        })?;
+
+        let mut req = self
+            .client()
+            .post(&url)
+            .bearer_auth(self.api_key_str())
+            .header("Content-Type", "application/json")
+            .body(body);
+
+        for (name, value) in crate::session::session_headers() {
+            req = req.header(name, value);
+        }
+        for (name, value) in crate::metrics::metrics_headers(self.metrics_provider()) {
+            req = req.header(name, value);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| reqwest_err_sanitized(e, self.api_key_str()))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let body = resp.bytes().await.unwrap_or_default();
+            return Err(from_http_status_sanitized(
+                status,
+                &body,
+                self.api_key_str(),
+            ));
+        }
+
+        let response: LockAcquireResponse = resp
+            .json()
+            .await
+            .map_err(|e| BackendError::transient(format!("failed to parse lock response: {e}")))?;
+
+        Ok(response.lock_id)
+    }
+
+    async fn release_lock(&self, key: &str, lock_id: &str) -> Result<bool, BackendError> {
+        let url = format!(
+            "{}/v1/cache/{}/lock?lock_id={}",
+            self.api_url().trim_end_matches('/'),
+            urlencoding::encode(key),
+            urlencoding::encode(lock_id),
+        );
+
+        let mut req = self
+            .client()
+            .delete(&url)
+            .bearer_auth(self.api_key_str());
+
+        for (name, value) in crate::session::session_headers() {
+            req = req.header(name, value);
+        }
+        for (name, value) in crate::metrics::metrics_headers(self.metrics_provider()) {
+            req = req.header(name, value);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| reqwest_err_sanitized(e, self.api_key_str()))?;
+
+        match resp.status().as_u16() {
+            200 | 204 => Ok(true),
+            404 => Ok(false),
+            status => {
+                let body = resp.bytes().await.unwrap_or_default();
+                Err(from_http_status_sanitized(
+                    status,
+                    &body,
+                    self.api_key_str(),
+                ))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Compile-time proof that CachekitIO implements LockableBackend.
+    fn _assert_lockable(_b: &dyn LockableBackend) {}
+
+    #[test]
+    fn cachekitio_is_lockable() {
+        fn _check(backend: &CachekitIO) {
+            _assert_lockable(backend);
+        }
+    }
+}

--- a/crates/cachekit/src/backend/cachekitio_lock.rs
+++ b/crates/cachekit/src/backend/cachekitio_lock.rs
@@ -80,10 +80,7 @@ impl LockableBackend for CachekitIO {
             urlencoding::encode(lock_id),
         );
 
-        let mut req = self
-            .client()
-            .delete(&url)
-            .bearer_auth(self.api_key_str());
+        let mut req = self.client().delete(&url).bearer_auth(self.api_key_str());
 
         for (name, value) in crate::session::session_headers() {
             req = req.header(name, value);

--- a/crates/cachekit/src/backend/cachekitio_ttl.rs
+++ b/crates/cachekit/src/backend/cachekitio_ttl.rs
@@ -29,10 +29,7 @@ impl TtlInspectable for CachekitIO {
             urlencoding::encode(key)
         );
 
-        let mut req = self
-            .client()
-            .get(&url)
-            .bearer_auth(self.api_key_str());
+        let mut req = self.client().get(&url).bearer_auth(self.api_key_str());
 
         for (name, value) in crate::session::session_headers() {
             req = req.header(name, value);
@@ -72,10 +69,7 @@ impl TtlInspectable for CachekitIO {
             urlencoding::encode(key)
         );
 
-        let body = serde_json::to_vec(&RefreshTtlRequest {
-            ttl: ttl.as_secs(),
-        })
-        .map_err(|e| {
+        let body = serde_json::to_vec(&RefreshTtlRequest { ttl: ttl.as_secs() }).map_err(|e| {
             BackendError::permanent(format!("failed to serialize refresh_ttl request: {e}"))
         })?;
 

--- a/crates/cachekit/src/backend/cachekitio_ttl.rs
+++ b/crates/cachekit/src/backend/cachekitio_ttl.rs
@@ -1,0 +1,129 @@
+//! [`TtlInspectable`] implementation for the cachekit.io HTTP backend.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use super::cachekitio::{from_http_status_sanitized, reqwest_err_sanitized, CachekitIO};
+use super::TtlInspectable;
+use crate::error::BackendError;
+
+#[derive(Deserialize)]
+struct TtlResponse {
+    ttl: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct RefreshTtlRequest {
+    ttl: u64,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[async_trait]
+impl TtlInspectable for CachekitIO {
+    async fn ttl(&self, key: &str) -> Result<Option<Duration>, BackendError> {
+        let url = format!(
+            "{}/v1/cache/{}/ttl",
+            self.api_url().trim_end_matches('/'),
+            urlencoding::encode(key)
+        );
+
+        let mut req = self
+            .client()
+            .get(&url)
+            .bearer_auth(self.api_key_str());
+
+        for (name, value) in crate::session::session_headers() {
+            req = req.header(name, value);
+        }
+        for (name, value) in crate::metrics::metrics_headers(self.metrics_provider()) {
+            req = req.header(name, value);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| reqwest_err_sanitized(e, self.api_key_str()))?;
+
+        match resp.status().as_u16() {
+            200 => {
+                let body: TtlResponse = resp.json().await.map_err(|e| {
+                    BackendError::transient(format!("failed to parse TTL response: {e}"))
+                })?;
+                Ok(body.ttl.map(Duration::from_secs))
+            }
+            404 => Ok(None),
+            status => {
+                let body = resp.bytes().await.unwrap_or_default();
+                Err(from_http_status_sanitized(
+                    status,
+                    &body,
+                    self.api_key_str(),
+                ))
+            }
+        }
+    }
+
+    async fn refresh_ttl(&self, key: &str, ttl: Duration) -> Result<bool, BackendError> {
+        let url = format!(
+            "{}/v1/cache/{}/ttl",
+            self.api_url().trim_end_matches('/'),
+            urlencoding::encode(key)
+        );
+
+        let body = serde_json::to_vec(&RefreshTtlRequest {
+            ttl: ttl.as_secs(),
+        })
+        .map_err(|e| {
+            BackendError::permanent(format!("failed to serialize refresh_ttl request: {e}"))
+        })?;
+
+        let mut req = self
+            .client()
+            .patch(&url)
+            .bearer_auth(self.api_key_str())
+            .header("Content-Type", "application/json")
+            .body(body);
+
+        for (name, value) in crate::session::session_headers() {
+            req = req.header(name, value);
+        }
+        for (name, value) in crate::metrics::metrics_headers(self.metrics_provider()) {
+            req = req.header(name, value);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| reqwest_err_sanitized(e, self.api_key_str()))?;
+
+        match resp.status().as_u16() {
+            200 | 204 => Ok(true),
+            404 => Ok(false),
+            status => {
+                let body_bytes = resp.bytes().await.unwrap_or_default();
+                Err(from_http_status_sanitized(
+                    status,
+                    &body_bytes,
+                    self.api_key_str(),
+                ))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Compile-time proof that CachekitIO implements TtlInspectable.
+    fn _assert_ttl_inspectable(_b: &dyn TtlInspectable) {}
+
+    #[test]
+    fn cachekitio_is_ttl_inspectable() {
+        fn _check(backend: &CachekitIO) {
+            _assert_ttl_inspectable(backend);
+        }
+    }
+}

--- a/crates/cachekit/src/backend/mod.rs
+++ b/crates/cachekit/src/backend/mod.rs
@@ -75,18 +75,62 @@ pub trait TtlInspectable: Backend {
     /// Return the remaining TTL for `key`, or `None` if the key does not exist
     /// or has no expiry.
     async fn ttl(&self, key: &str) -> Result<Option<Duration>, BackendError>;
+
+    /// Refresh the TTL on an existing key. Default: not supported.
+    async fn refresh_ttl(&self, _key: &str, _ttl: Duration) -> Result<bool, BackendError> {
+        Err(BackendError::permanent(
+            "refresh_ttl not supported by this backend",
+        ))
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
 #[async_trait(?Send)]
 pub trait TtlInspectable: Backend {
     async fn ttl(&self, key: &str) -> Result<Option<Duration>, BackendError>;
+
+    async fn refresh_ttl(&self, _key: &str, _ttl: Duration) -> Result<bool, BackendError> {
+        Err(BackendError::permanent(
+            "refresh_ttl not supported by this backend",
+        ))
+    }
+}
+
+// ── LockableBackend ─────────────────────────────────────────────────────────
+
+/// Optional extension for backends that support distributed locking.
+#[cfg(not(target_arch = "wasm32"))]
+#[async_trait]
+pub trait LockableBackend: Backend {
+    /// Acquire a distributed lock. Returns lock_id if acquired, None if contested.
+    async fn acquire_lock(
+        &self,
+        key: &str,
+        timeout_ms: u64,
+    ) -> Result<Option<String>, BackendError>;
+    /// Release a distributed lock. Returns true if released.
+    async fn release_lock(&self, key: &str, lock_id: &str) -> Result<bool, BackendError>;
+}
+
+#[cfg(target_arch = "wasm32")]
+#[async_trait(?Send)]
+pub trait LockableBackend: Backend {
+    async fn acquire_lock(
+        &self,
+        key: &str,
+        timeout_ms: u64,
+    ) -> Result<Option<String>, BackendError>;
+    async fn release_lock(&self, key: &str, lock_id: &str) -> Result<bool, BackendError>;
 }
 
 // ── Feature-gated backend modules ─────────────────────────────────────────────
 
 #[cfg(feature = "cachekitio")]
 pub mod cachekitio;
+#[cfg(feature = "cachekitio")]
+mod cachekitio_lock;
+#[cfg(feature = "cachekitio")]
+mod cachekitio_ttl;
 
 #[cfg(feature = "redis")]
 pub mod redis;

--- a/crates/cachekit/src/backend/workers.rs
+++ b/crates/cachekit/src/backend/workers.rs
@@ -130,15 +130,12 @@ impl WorkersCachekitIO {
             ))
         })?;
 
-        worker::Fetch::Request(request)
-            .send()
-            .await
-            .map_err(|e| {
-                BackendError::transient(BackendError::sanitize_message(
-                    &format!("fetch failed: {e}"),
-                    self.api_key.as_str(),
-                ))
-            })
+        worker::Fetch::Request(request).send().await.map_err(|e| {
+            BackendError::transient(BackendError::sanitize_message(
+                &format!("fetch failed: {e}"),
+                self.api_key.as_str(),
+            ))
+        })
     }
 }
 
@@ -151,15 +148,12 @@ impl Backend for WorkersCachekitIO {
 
         match resp.status_code() {
             200 => {
-                let bytes = resp
-                    .bytes()
-                    .await
-                    .map_err(|e| {
-                        BackendError::transient(BackendError::sanitize_message(
-                            &format!("failed to read body: {e}"),
-                            self.api_key.as_str(),
-                        ))
-                    })?;
+                let bytes = resp.bytes().await.map_err(|e| {
+                    BackendError::transient(BackendError::sanitize_message(
+                        &format!("failed to read body: {e}"),
+                        self.api_key.as_str(),
+                    ))
+                })?;
                 Ok(Some(bytes))
             }
             404 => Ok(None),

--- a/crates/cachekit/src/backend/workers.rs
+++ b/crates/cachekit/src/backend/workers.rs
@@ -12,6 +12,9 @@ use zeroize::Zeroizing;
 
 use crate::backend::{Backend, HealthStatus};
 use crate::error::BackendError;
+use crate::metrics::{metrics_headers, MetricsProvider};
+use crate::session::session_headers;
+use crate::url_validator::validate_cachekitio_url;
 
 // ── WorkersCachekitIO ────────────────────────────────────────────────────────
 
@@ -22,6 +25,7 @@ use crate::error::BackendError;
 pub struct WorkersCachekitIO {
     api_key: Zeroizing<String>,
     api_url: String,
+    metrics_provider: Option<MetricsProvider>,
 }
 
 /// Redact `api_key` from debug output.
@@ -57,7 +61,7 @@ impl WorkersCachekitIO {
 
     /// Build the health-check URL.
     fn health_url(&self) -> String {
-        format!("{}/v1/health", self.api_url.trim_end_matches('/'))
+        format!("{}/v1/cache/health", self.api_url.trim_end_matches('/'))
     }
 
     /// Execute a fetch request with the given method, URL, optional body, and extra headers.
@@ -74,11 +78,33 @@ impl WorkersCachekitIO {
                 "Authorization",
                 &format!("Bearer {}", self.api_key.as_str()),
             )
-            .map_err(|e| BackendError::permanent(format!("failed to set auth header: {e}")))?;
+            .map_err(|e| {
+                BackendError::permanent(BackendError::sanitize_message(
+                    &format!("failed to set auth header: {e}"),
+                    self.api_key.as_str(),
+                ))
+            })?;
 
         for (name, value) in extra_headers {
             headers.set(name, &value).map_err(|e| {
-                BackendError::permanent(format!("failed to set header {name}: {e}"))
+                BackendError::permanent(BackendError::sanitize_message(
+                    &format!("failed to set header {name}: {e}"),
+                    self.api_key.as_str(),
+                ))
+            })?;
+        }
+
+        // Inject session headers
+        for (name, value) in session_headers() {
+            headers.set(name, &value).map_err(|e| {
+                BackendError::permanent(format!("failed to set session header {name}: {e}"))
+            })?;
+        }
+
+        // Inject metrics headers
+        for (name, value) in metrics_headers(self.metrics_provider.as_ref()) {
+            headers.set(name, &value).map_err(|e| {
+                BackendError::permanent(format!("failed to set metrics header {name}: {e}"))
             })?;
         }
 
@@ -97,13 +123,22 @@ impl WorkersCachekitIO {
             init.with_body(Some(js_array.into()));
         }
 
-        let request = worker::Request::new_with_init(url, &init)
-            .map_err(|e| BackendError::transient(format!("failed to build request: {e}")))?;
+        let request = worker::Request::new_with_init(url, &init).map_err(|e| {
+            BackendError::transient(BackendError::sanitize_message(
+                &format!("failed to build request: {e}"),
+                self.api_key.as_str(),
+            ))
+        })?;
 
         worker::Fetch::Request(request)
             .send()
             .await
-            .map_err(|e| BackendError::transient(format!("fetch failed: {e}")))
+            .map_err(|e| {
+                BackendError::transient(BackendError::sanitize_message(
+                    &format!("fetch failed: {e}"),
+                    self.api_key.as_str(),
+                ))
+            })
     }
 }
 
@@ -119,13 +154,22 @@ impl Backend for WorkersCachekitIO {
                 let bytes = resp
                     .bytes()
                     .await
-                    .map_err(|e| BackendError::transient(format!("failed to read body: {e}")))?;
+                    .map_err(|e| {
+                        BackendError::transient(BackendError::sanitize_message(
+                            &format!("failed to read body: {e}"),
+                            self.api_key.as_str(),
+                        ))
+                    })?;
                 Ok(Some(bytes))
             }
             404 => Ok(None),
             status => {
                 let body = resp.bytes().await.unwrap_or_default();
-                Err(BackendError::from_http_status(status, &body))
+                let sanitized = BackendError::sanitize_message(
+                    std::str::from_utf8(&body).unwrap_or(""),
+                    self.api_key.as_str(),
+                );
+                Err(BackendError::from_http_status(status, sanitized.as_bytes()))
             }
         }
     }
@@ -138,7 +182,7 @@ impl Backend for WorkersCachekitIO {
     ) -> Result<(), BackendError> {
         let mut headers = vec![("Content-Type", "application/octet-stream".to_owned())];
         if let Some(ttl) = ttl {
-            headers.push(("X-Cache-TTL", ttl.as_secs().to_string()));
+            headers.push(("X-TTL", ttl.as_secs().to_string()));
         }
 
         let mut resp = self
@@ -150,7 +194,11 @@ impl Backend for WorkersCachekitIO {
             Ok(())
         } else {
             let body = resp.bytes().await.unwrap_or_default();
-            Err(BackendError::from_http_status(status, &body))
+            let sanitized = BackendError::sanitize_message(
+                std::str::from_utf8(&body).unwrap_or(""),
+                self.api_key.as_str(),
+            );
+            Err(BackendError::from_http_status(status, sanitized.as_bytes()))
         }
     }
 
@@ -162,7 +210,11 @@ impl Backend for WorkersCachekitIO {
             404 => Ok(false),
             status => {
                 let body = resp.bytes().await.unwrap_or_default();
-                Err(BackendError::from_http_status(status, &body))
+                let sanitized = BackendError::sanitize_message(
+                    std::str::from_utf8(&body).unwrap_or(""),
+                    self.api_key.as_str(),
+                );
+                Err(BackendError::from_http_status(status, sanitized.as_bytes()))
             }
         }
     }
@@ -192,7 +244,11 @@ impl Backend for WorkersCachekitIO {
             })
         } else {
             let body = resp.bytes().await.unwrap_or_default();
-            Err(BackendError::from_http_status(status, &body))
+            let sanitized = BackendError::sanitize_message(
+                std::str::from_utf8(&body).unwrap_or(""),
+                self.api_key.as_str(),
+            );
+            Err(BackendError::from_http_status(status, sanitized.as_bytes()))
         }
     }
 }
@@ -204,6 +260,8 @@ impl Backend for WorkersCachekitIO {
 pub struct WorkersCachekitIOBuilder {
     api_key: Option<String>,
     api_url: Option<String>,
+    allow_custom_host: bool,
+    metrics_provider: Option<MetricsProvider>,
 }
 
 impl WorkersCachekitIOBuilder {
@@ -219,6 +277,18 @@ impl WorkersCachekitIOBuilder {
         self
     }
 
+    /// Allow non-standard hostnames (e.g. custom proxies). Private IPs are still blocked.
+    pub fn allow_custom_host(mut self, allow: bool) -> Self {
+        self.allow_custom_host = allow;
+        self
+    }
+
+    /// Provide L1 cache metrics for request telemetry headers.
+    pub fn metrics_provider(mut self, provider: MetricsProvider) -> Self {
+        self.metrics_provider = Some(provider);
+        self
+    }
+
     /// Consume the builder and construct a [`WorkersCachekitIO`].
     ///
     /// # Errors
@@ -226,6 +296,7 @@ impl WorkersCachekitIOBuilder {
     /// Returns an error if:
     /// - `api_key` was not set or is empty.
     /// - the resolved URL scheme is not `https`.
+    /// - the URL hostname is not permitted (see [`validate_cachekitio_url`]).
     pub fn build(self) -> Result<WorkersCachekitIO, crate::error::CachekitError> {
         use crate::error::CachekitError;
 
@@ -238,17 +309,13 @@ impl WorkersCachekitIOBuilder {
             .api_url
             .unwrap_or_else(|| "https://api.cachekit.io".to_string());
 
-        // Enforce HTTPS — plaintext HTTP must never transmit API keys.
-        if !api_url.starts_with("https://") {
-            return Err(CachekitError::Config(format!(
-                "api_url must use HTTPS, got: {}",
-                api_url
-            )));
-        }
+        // Validate URL: HTTPS, allowed host, no private IPs.
+        validate_cachekitio_url(&api_url, self.allow_custom_host)?;
 
         Ok(WorkersCachekitIO {
             api_key: Zeroizing::new(api_key),
             api_url,
+            metrics_provider: self.metrics_provider,
         })
     }
 }

--- a/crates/cachekit/src/error.rs
+++ b/crates/cachekit/src/error.rs
@@ -118,6 +118,14 @@ impl BackendError {
         }
     }
 
+    /// Sanitize error messages to strip API keys (CWE-532).
+    pub fn sanitize_message(msg: &str, api_key: &str) -> String {
+        if api_key.is_empty() {
+            return msg.to_string();
+        }
+        msg.replace(api_key, "***")
+    }
+
     /// Construct a [`BackendError`] from an HTTP status code and response body.
     ///
     /// The body is truncated to 256 Unicode scalar values to avoid inflating error messages.

--- a/crates/cachekit/src/lib.rs
+++ b/crates/cachekit/src/lib.rs
@@ -17,7 +17,10 @@ pub mod client;
 pub mod config;
 pub mod error;
 pub mod key;
+pub mod metrics;
 pub mod serializer;
+pub mod session;
+pub mod url_validator;
 
 #[cfg(feature = "encryption")]
 pub mod encryption;

--- a/crates/cachekit/src/metrics.rs
+++ b/crates/cachekit/src/metrics.rs
@@ -78,7 +78,10 @@ mod tests {
             })
         });
         let headers = metrics_headers(Some(&provider));
-        let rate = headers.iter().find(|h| h.0 == "X-CacheKit-L1-Hit-Rate").unwrap();
+        let rate = headers
+            .iter()
+            .find(|h| h.0 == "X-CacheKit-L1-Hit-Rate")
+            .unwrap();
         assert_eq!(rate.1, "0.300"); // 3 / (3+2+5)
     }
 
@@ -93,7 +96,10 @@ mod tests {
             })
         });
         let headers = metrics_headers(Some(&provider));
-        let rate = headers.iter().find(|h| h.0 == "X-CacheKit-L1-Hit-Rate").unwrap();
+        let rate = headers
+            .iter()
+            .find(|h| h.0 == "X-CacheKit-L1-Hit-Rate")
+            .unwrap();
         assert_eq!(rate.1, "0.000");
     }
 

--- a/crates/cachekit/src/metrics.rs
+++ b/crates/cachekit/src/metrics.rs
@@ -1,0 +1,106 @@
+use std::sync::Arc;
+
+pub struct L1Stats {
+    pub l1_hits: u64,
+    pub l2_hits: u64,
+    pub misses: u64,
+    pub l1_enabled: bool,
+}
+
+pub type MetricsProvider = Arc<dyn Fn() -> Option<L1Stats> + Send + Sync>;
+
+pub fn metrics_headers(provider: Option<&MetricsProvider>) -> Vec<(&'static str, String)> {
+    let disabled = vec![("X-CacheKit-L1-Status", "disabled".to_string())];
+
+    let provider = match provider {
+        Some(p) => p,
+        None => return disabled,
+    };
+
+    let stats = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| (provider)())) {
+        Ok(Some(s)) => s,
+        _ => return disabled,
+    };
+
+    if !stats.l1_enabled {
+        return disabled;
+    }
+
+    let total = stats.l1_hits + stats.l2_hits + stats.misses;
+    let hit_rate = if total > 0 {
+        stats.l1_hits as f64 / total as f64
+    } else {
+        0.0
+    };
+
+    vec![
+        ("X-CacheKit-L1-Status", "miss".to_string()),
+        ("X-CacheKit-L1-Hits", stats.l1_hits.to_string()),
+        ("X-CacheKit-L2-Hits", stats.l2_hits.to_string()),
+        ("X-CacheKit-Misses", stats.misses.to_string()),
+        ("X-CacheKit-L1-Hit-Rate", format!("{:.3}", hit_rate)),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_when_no_provider() {
+        let headers = metrics_headers(None);
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers[0], ("X-CacheKit-L1-Status", "disabled".to_string()));
+    }
+
+    #[test]
+    fn disabled_when_l1_not_enabled() {
+        let provider: MetricsProvider = Arc::new(|| {
+            Some(L1Stats {
+                l1_hits: 0,
+                l2_hits: 0,
+                misses: 0,
+                l1_enabled: false,
+            })
+        });
+        let headers = metrics_headers(Some(&provider));
+        assert_eq!(headers[0].1, "disabled");
+    }
+
+    #[test]
+    fn correct_hit_rate_calculation() {
+        let provider: MetricsProvider = Arc::new(|| {
+            Some(L1Stats {
+                l1_hits: 3,
+                l2_hits: 2,
+                misses: 5,
+                l1_enabled: true,
+            })
+        });
+        let headers = metrics_headers(Some(&provider));
+        let rate = headers.iter().find(|h| h.0 == "X-CacheKit-L1-Hit-Rate").unwrap();
+        assert_eq!(rate.1, "0.300"); // 3 / (3+2+5)
+    }
+
+    #[test]
+    fn zero_division_guard() {
+        let provider: MetricsProvider = Arc::new(|| {
+            Some(L1Stats {
+                l1_hits: 0,
+                l2_hits: 0,
+                misses: 0,
+                l1_enabled: true,
+            })
+        });
+        let headers = metrics_headers(Some(&provider));
+        let rate = headers.iter().find(|h| h.0 == "X-CacheKit-L1-Hit-Rate").unwrap();
+        assert_eq!(rate.1, "0.000");
+    }
+
+    #[test]
+    fn disabled_when_provider_panics() {
+        let provider: MetricsProvider = Arc::new(|| panic!("boom"));
+        let headers = metrics_headers(Some(&provider));
+        assert_eq!(headers[0].1, "disabled");
+    }
+}

--- a/crates/cachekit/src/session.rs
+++ b/crates/cachekit/src/session.rs
@@ -1,0 +1,59 @@
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct SessionInfo {
+    id: String,
+    start_ms: u64,
+}
+
+static SESSION: OnceLock<SessionInfo> = OnceLock::new();
+
+fn get_or_create() -> &'static SessionInfo {
+    SESSION.get_or_init(|| {
+        let id = uuid::Uuid::new_v4().to_string();
+        let start_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        SessionInfo { id, start_ms }
+    })
+}
+
+pub fn session_headers() -> [(&'static str, String); 2] {
+    let s = get_or_create();
+    [
+        ("X-CacheKit-Session-ID", s.id.clone()),
+        ("X-CacheKit-Session-Start", s.start_ms.to_string()),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_id_is_uuid_v4_format() {
+        let headers = session_headers();
+        let id = &headers[0].1;
+        assert!(uuid::Uuid::parse_str(id).is_ok(), "Session ID should be valid UUID");
+        let parsed = uuid::Uuid::parse_str(id).unwrap();
+        assert_eq!(parsed.get_version_num(), 4, "Should be UUID v4");
+    }
+
+    #[test]
+    fn session_start_is_reasonable_epoch_millis() {
+        let headers = session_headers();
+        let start_ms: u64 = headers[1].1.parse().expect("Should be numeric");
+        // Should be after 2024-01-01 and before 2030-01-01
+        assert!(start_ms > 1_704_067_200_000, "Should be after 2024");
+        assert!(start_ms < 1_893_456_000_000, "Should be before 2030");
+    }
+
+    #[test]
+    fn session_is_stable_across_calls() {
+        let h1 = session_headers();
+        let h2 = session_headers();
+        assert_eq!(h1[0].1, h2[0].1, "Session ID should be stable");
+        assert_eq!(h1[1].1, h2[1].1, "Session start should be stable");
+    }
+}

--- a/crates/cachekit/src/session.rs
+++ b/crates/cachekit/src/session.rs
@@ -35,7 +35,10 @@ mod tests {
     fn session_id_is_uuid_v4_format() {
         let headers = session_headers();
         let id = &headers[0].1;
-        assert!(uuid::Uuid::parse_str(id).is_ok(), "Session ID should be valid UUID");
+        assert!(
+            uuid::Uuid::parse_str(id).is_ok(),
+            "Session ID should be valid UUID"
+        );
         let parsed = uuid::Uuid::parse_str(id).unwrap();
         assert_eq!(parsed.get_version_num(), 4, "Should be UUID v4");
     }

--- a/crates/cachekit/src/url_validator.rs
+++ b/crates/cachekit/src/url_validator.rs
@@ -2,9 +2,12 @@ use crate::error::CachekitError;
 
 const ALLOWED_HOSTS: &[&str] = &["api.cachekit.io", "api.staging.cachekit.io"];
 
-pub fn validate_cachekitio_url(url_str: &str, allow_custom_host: bool) -> Result<(), CachekitError> {
-    let parsed =
-        url::Url::parse(url_str).map_err(|_| CachekitError::Config("CachekitIO API URL is malformed".to_string()))?;
+pub fn validate_cachekitio_url(
+    url_str: &str,
+    allow_custom_host: bool,
+) -> Result<(), CachekitError> {
+    let parsed = url::Url::parse(url_str)
+        .map_err(|_| CachekitError::Config("CachekitIO API URL is malformed".to_string()))?;
 
     if parsed.scheme() != "https" {
         return Err(CachekitError::Config(
@@ -34,7 +37,11 @@ pub fn validate_cachekitio_url(url_str: &str, allow_custom_host: bool) -> Result
 fn is_private_ip(ip: std::net::IpAddr) -> bool {
     match ip {
         std::net::IpAddr::V4(v4) => {
-            v4.is_loopback() || v4.is_private() || v4.is_link_local() || v4.is_unspecified() || v4.octets()[0] == 0
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.octets()[0] == 0
         }
         std::net::IpAddr::V6(v6) => {
             v6.is_loopback()
@@ -87,7 +94,10 @@ mod tests {
     fn generic_error_message() {
         let err = validate_cachekitio_url("https://evil.com", false).unwrap_err();
         let msg = err.to_string();
-        assert!(!msg.contains("api.cachekit.io"), "Should not enumerate allowlist");
+        assert!(
+            !msg.contains("api.cachekit.io"),
+            "Should not enumerate allowlist"
+        );
         assert!(
             !msg.contains("allow_custom_host"),
             "Should not reveal bypass flag"

--- a/crates/cachekit/src/url_validator.rs
+++ b/crates/cachekit/src/url_validator.rs
@@ -1,0 +1,96 @@
+use crate::error::CachekitError;
+
+const ALLOWED_HOSTS: &[&str] = &["api.cachekit.io", "api.staging.cachekit.io"];
+
+pub fn validate_cachekitio_url(url_str: &str, allow_custom_host: bool) -> Result<(), CachekitError> {
+    let parsed =
+        url::Url::parse(url_str).map_err(|_| CachekitError::Config("CachekitIO API URL is malformed".to_string()))?;
+
+    if parsed.scheme() != "https" {
+        return Err(CachekitError::Config(
+            "CachekitIO API URL must use HTTPS".to_string(),
+        ));
+    }
+
+    if let Some(host) = parsed.host_str() {
+        if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+            if is_private_ip(ip) {
+                return Err(CachekitError::Config(
+                    "CachekitIO API URL must not point to a private IP address".to_string(),
+                ));
+            }
+        }
+
+        if !allow_custom_host && !ALLOWED_HOSTS.contains(&host) {
+            return Err(CachekitError::Config(
+                "API URL hostname not permitted. See documentation.".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn is_private_ip(ip: std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => {
+            v4.is_loopback() || v4.is_private() || v4.is_link_local() || v4.is_unspecified() || v4.octets()[0] == 0
+        }
+        std::net::IpAddr::V6(v6) => {
+            v6.is_loopback()
+                || v6.is_unspecified()
+                // fe80::/10 (link-local) and fc00::/7 (unique local)
+                || (v6.segments()[0] & 0xffc0) == 0xfe80
+                || (v6.segments()[0] & 0xfe00) == 0xfc00
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_production_url() {
+        assert!(validate_cachekitio_url("https://api.cachekit.io", false).is_ok());
+    }
+
+    #[test]
+    fn accepts_staging_url() {
+        assert!(validate_cachekitio_url("https://api.staging.cachekit.io", false).is_ok());
+    }
+
+    #[test]
+    fn rejects_http() {
+        assert!(validate_cachekitio_url("http://api.cachekit.io", false).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_host() {
+        assert!(validate_cachekitio_url("https://evil.com", false).is_err());
+    }
+
+    #[test]
+    fn allows_custom_host() {
+        assert!(validate_cachekitio_url("https://my-proxy.internal.com", true).is_ok());
+    }
+
+    #[test]
+    fn blocks_private_ips_even_with_custom_host() {
+        assert!(validate_cachekitio_url("https://127.0.0.1", true).is_err());
+        assert!(validate_cachekitio_url("https://10.0.0.1", true).is_err());
+        assert!(validate_cachekitio_url("https://192.168.1.1", true).is_err());
+        assert!(validate_cachekitio_url("https://169.254.169.254", true).is_err());
+    }
+
+    #[test]
+    fn generic_error_message() {
+        let err = validate_cachekitio_url("https://evil.com", false).unwrap_err();
+        let msg = err.to_string();
+        assert!(!msg.contains("api.cachekit.io"), "Should not enumerate allowlist");
+        assert!(
+            !msg.contains("allow_custom_host"),
+            "Should not reveal bypass flag"
+        );
+    }
+}

--- a/crates/cachekit/tests/cachekitio_tests.rs
+++ b/crates/cachekit/tests/cachekitio_tests.rs
@@ -8,6 +8,7 @@ fn cachekitio_builder() {
     let backend = CachekitIO::builder()
         .api_key("test-api-key")
         .api_url("https://api.example.com")
+        .allow_custom_host(true)
         .build()
         .expect("build should succeed");
 


### PR DESCRIPTION
## Summary

CachekitIO backend full parity with the Python reference implementation, using trait-separated architecture.

- Session tracking (OnceLock-based, UUID v4 via `uuid` crate with CSPRNG)
- L1 metrics headers (panic-safe provider, defaults to `disabled`)
- SSRF protection (hostname allowlist + `std::net::IpAddr` range checks)
- Error sanitization (`sanitize_message` strips API key from all error paths, CWE-532)
- Health endpoint fix (/v1/health → /v1/cache/health, both native + Workers)
- LockableBackend trait + CachekitIO impl (POST/DELETE /v1/cache/{key}/lock)
- TtlInspectable extended with refresh_ttl (default impl for backwards compat)
- Lock release uses query param (matches SaaS: `url.searchParams.get('lock_id')`)
- Builder gains `allow_custom_host()` and `metrics_provider()`

### Architecture

Core `CachekitIO` struct handles HTTP translation + cross-cutting concerns.
Lock and TTL in separate files (`cachekitio_lock.rs`, `cachekitio_ttl.rs`) with own trait impls.
Workers backend gets session + metrics but NOT locking/TTL (edge round-trips too expensive).

### New files (5)
- `session.rs`, `url_validator.rs`, `metrics.rs`
- `cachekitio_lock.rs`, `cachekitio_ttl.rs`

### New deps
- `url` 2, `uuid` 1 (v4), `serde_json` (optional, cachekitio feature)

## Test plan

- [x] 102+ tests passing
- [x] Zero clippy warnings
- [x] Expert panel review: security specialist approved (2 rounds)
- [x] Bug hunter review: all critical findings fixed (TTL field name, lock release protocol, Workers health)
