### PR TITLE
ci: update create-github-app-token to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: actions/create-github-app-token@e6bbaada0dce03cba6c8c531ef49f15965adc8ab # v2
+      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
         id: app-token
         with:
           app-id: ${{ secrets.APP_ID }}


### PR DESCRIPTION
## Summary
- Update `actions/create-github-app-token` from stale v2 SHA to v3 (`f8d387b`)
- Old SHA (`e6bbaada`) was garbage-collected, causing release workflow to fail with URI resolution error

## Context
- Failed run: https://github.com/cachekit-io/cachekit-rs/actions/runs/23292915005
- v3 breaking changes (Node 24, proxy handling) don't affect us