### PR TITLE
Fix release-please workspace version sync

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "rust",
+  "group": "cachekit-rs",
   "changelog-sections": [
     {"type": "feat", "section": "Features"},
     {"type": "fix", "section": "Bug Fixes"},
@@ -22,7 +23,7 @@
     },
     "crates/cachekit-macros": {
       "package-name": "cachekit-macros",
-      "changelog-path": "crates/cachekit-macros/CHANGELOG.md",
+      "changelog-path": "CHANGELOG.md",
       "component": "cachekit-macros"
     }
   }


### PR DESCRIPTION
## Summary

- Add `group` key to release-please-config.json so both crates are versioned together
- Fix macros `changelog-path` — was relative to repo root causing doubled path (`crates/cachekit-macros/crates/cachekit-macros/CHANGELOG.md`)

## Context

PR #5 (release-please) fails CI because `cachekit-macros` was bumped to `0.2.0` but the dependency in `crates/cachekit/Cargo.toml` still says `^0.1`. The `group` key tells release-please to update cross-crate version refs when bumping.

## Test plan

- [ ] Merge this, release-please regenerates PR #5 with correct version refs
- [ ] PR #5 CI passes