### PR TITLE
Fix release-please: use cargo-workspace + linked-versions plugins

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "rust",
-  "group": "cachekit-rs",
   "changelog-sections": [
     {"type": "feat", "section": "Features"},
     {"type": "fix", "section": "Bug Fixes"},
@@ -14,6 +13,17 @@
     {"type": "test", "section": "Tests", "hidden": true},
     {"type": "ci", "section": "CI/CD", "hidden": true},
     {"type": "build", "section": "Build System", "hidden": true}
+  ],
+  "plugins": [
+    {
+      "type": "cargo-workspace",
+      "merge": false
+    },
+    {
+      "type": "linked-versions",
+      "groupName": "cachekit-rs",
+      "components": ["cachekit-rs", "cachekit-macros"]
+    }
   ],
   "packages": {
     "crates/cachekit": {


### PR DESCRIPTION
## Summary

- Replace non-functional `group` top-level key with proper plugins:
  - **`cargo-workspace`**: updates `Cargo.toml` dependency version specs when a workspace crate is bumped (fixes `cachekit-macros = "^0.1"` not being updated to `"^0.2"`)
  - **`linked-versions`**: keeps `cachekit-rs` and `cachekit-macros` at the same version

## Context

PR #5 (release-please) bumped `cachekit-macros` to `0.2.0` but left the dependency in `crates/cachekit/Cargo.toml` at `^0.1`, breaking all CI jobs.

## Test plan

- [ ] Merge this, release-please regenerates PR #5
- [ ] PR #5 diff includes updated macros dep version in `crates/cachekit/Cargo.toml`
- [ ] PR #5 CI passes
