### PR TITLE
ci: fix publish job trigger for multi-crate workspace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,9 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
+      release_created: ${{ steps.release.outputs['crates/cachekit--release_created'] }}
+      tag_name: ${{ steps.release.outputs['crates/cachekit--tag_name'] }}
+      macros_release_created: ${{ steps.release.outputs['crates/cachekit-macros--release_created'] }}
     steps:
       - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
         id: app-token
@@ -27,9 +28,12 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Debug release-please outputs
+        run: echo '${{ toJSON(steps.release.outputs) }}'
+
   publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

The v0.2.0 publish job was skipped because the workflow checked `release_created` (bare), but release-please v4 with `cargo-workspace` plugin outputs package-specific keys like `crates/cachekit--release_created`.

- Use `steps.release.outputs['crates/cachekit--release_created']` instead
- Add debug step to log all release-please outputs

## Context

v0.2.0 GitHub releases were created successfully but `cargo publish` never ran. This was a one-time manual publish for v0.2.0; this fix prevents recurrence on all future releases.