### PR TITLE
chore: add org-canonical .coderabbit.yaml

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-AU"
+early_access: false
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+
+  path_instructions:
+    - path: "**/*.rs"
+      instructions: |
+        Rust code. Check for unsafe blocks, unwrap abuse, missing error propagation,
+        and clippy-level issues. Prefer Result over panic. Pay special attention to
+        FFI boundaries (NAPI, PyO3) — verify buffer lengths, null checks, and that
+        keys/secrets are zeroized on drop.
+    - path: "**/*.py"
+      instructions: |
+        Python code. Enforce ruff compatibility, type hints on public APIs,
+        guard clauses over nesting. No bare except clauses. Secrets must use
+        pydantic SecretStr. Config via pydantic-settings only.
+    - path: "**/*.ts"
+      instructions: |
+        TypeScript code. Strict mode, no `any` types on public APIs.
+        Verify async error handling — no unhandled promise rejections.
+        Check that NAPI bindings match Rust function signatures exactly.
+    - path: "**/encryption/**"
+      instructions: |
+        Security-critical encryption code. Verify AAD v0x03 format compliance,
+        key length validation (exactly 32 bytes), nonce uniqueness, and that
+        keys never leak into error messages or logs. Cross-reference with
+        protocol spec at https://github.com/cachekit-io/protocol.
+    - path: ".github/workflows/**"
+      instructions: |
+        GitHub Actions workflows. All actions MUST be pinned to full 40-char SHA
+        with a version comment (e.g., @abc123 # v6). Never use tag refs.
+    - path: "**/Dockerfile*"
+      instructions: |
+        Dockerfiles. Check for missing cleanup (rm -rf /var/lib/apt/lists/*),
+        unnecessary layers, running as root, and unpinned base images.
+
+  tools:
+    shellcheck:
+      enabled: true
+    actionlint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    ruff:
+      enabled: true
+    yamllint:
+      enabled: true
+    hadolint:
+      enabled: true
+    biome:
+      enabled: true
+    eslint:
+      enabled: true
+
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,7 @@
+# This configuration is a copy of the organization-canonical CodeRabbit config.
+# Source of truth: cachekit-io/.github/.coderabbit.yaml
+# Keep this file in sync when the canonical version updates.
+#
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: "en-AU"
 early_access: false
@@ -40,7 +44,7 @@ reviews:
     - path: ".github/workflows/**"
       instructions: |
         GitHub Actions workflows. All actions MUST be pinned to full 40-char SHA
-        with a version comment (e.g., @abc123 # v6). Never use tag refs.
+        with a version comment (e.g., `@a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0` # v6). Never use tag refs.
     - path: "**/Dockerfile*"
       instructions: |
         Dockerfiles. Check for missing cleanup (rm -rf /var/lib/apt/lists/*),


### PR DESCRIPTION
CodeRabbit reads `.coderabbit.yaml` only from each repo's own root — the file at `cachekit-io/.github/.coderabbit.yaml` is **not** honored despite the GitHub convention working for CODEOWNERS / PR templates / Dependabot.

This PR adds the org-canonical CodeRabbit configuration to this repo so it takes effect:

- assertive review profile + path-specific instructions (Rust FFI safety, Python ruff/pydantic, TS strict mode, encryption-code AAD/key checks, workflow SHA-pinning, Dockerfile hygiene)
- `request_changes_workflow: true` (enables `@coderabbitai approve` / `@coderabbitai resolve` commands and auto-approve when comments are resolved)
- tools enabled: shellcheck, actionlint, gitleaks, ruff, yamllint, hadolint, biome, eslint

Source of truth: `cachekit-io/.github/.coderabbit.yaml`. Keep this file in sync when the canonical version updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added configuration to enable automated code review tooling and path-aware review rules.
  * Set review behaviour defaults and language to en-AU for reviews and summaries.
  * Enabled a set of static-analysis linters and checks to run automatically.
  * Turned on chat auto-reply to streamline review interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cachekit-io/cachekit-rs/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->