### PR TITLE
chore: drop misleading org-canonical source header from .coderabbit.yaml

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,3 @@
-# This configuration is a copy of the organization-canonical CodeRabbit config.
-# Source of truth: cachekit-io/.github/.coderabbit.yaml
-# Keep this file in sync when the canonical version updates.
-#
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: "en-AU"
 early_access: false


### PR DESCRIPTION
Removes the `Source of truth: cachekit-io/.github/.coderabbit.yaml / keep in sync` header added during the rollout.

CodeRabbit ignores org-level `.github/.coderabbit.yaml` (precedence is repo-root → dashboard), so that file is not load-bearing and there is no sync mechanism. The header risked the exact misconception that the org file configures this repo. The repo-root file is authoritative on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration file structure to improve developer tooling compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cachekit-io/cachekit-rs/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->