### PR TITLE
ci: cap cargo build parallelism to fix cachekit-lean MSRV OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,23 @@ env:
   # cross-device link errors on container overlay filesystems.
   RUSTUP_HOME: /tmp/rustup
   CARGO_HOME: /tmp/cargo
+  # The cachekit-lean ARC runner has a hard 6Gi memory cgroup (lab ADR-0001).
+  # cargo defaults -j to the visible core count (~24 via the pod's CPU limit),
+  # and a cold `cargo test` build of this 246-crate async/TLS/crypto graph with
+  # full test-profile debuginfo peaks above 6Gi at that fan-out — the kernel
+  # OOM-kills the linker and the runner "loses communication" (issue #25,
+  # confirmed by a 6Gi-cgroup repro). Cap parallel compile/link jobs so peak
+  # RSS stays well under the cap on the cache-less lean pod.
+  CARGO_BUILD_JOBS: "4"
 
 jobs:
   test:
     name: ${{ matrix.rust }}
     runs-on: cachekit-lean
+    # Backstop: a wedged/killed runner otherwise hangs ~10min until GitHub's
+    # heartbeat reckoning (issue #25). Fail fast — a healthy cold -j4 build of
+    # this tree finishes well inside this window.
+    timeout-minutes: 20
     continue-on-error: ${{ matrix.rust == 'beta' }}
     strategy:
       fail-fast: false
@@ -46,6 +58,7 @@ jobs:
   wasm:
     name: wasm32 compilation check
     runs-on: cachekit-lean
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,13 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: cachekit-lean
+    timeout-minutes: 30
     env:
       RUSTUP_HOME: /tmp/rustup
       CARGO_HOME: /tmp/cargo
+      # Same 6Gi cgroup OOM constraint as CI (issue #25): cap parallel jobs so
+      # the cold pre-publish build doesn't OOM-kill the linker on cachekit-lean.
+      CARGO_BUILD_JOBS: "4"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -48,6 +52,15 @@ jobs:
 
       - name: Run tests before publish
         run: cargo test --features "cachekitio,redis,encryption,l1,macros"
+
+      - name: Verify MSRV (1.85) before publish
+        # Gate: never ship a release that breaks the declared MSRV floor.
+        # release.yml previously built `stable` only, so a red MSRV job could
+        # publish silently (issue #25). `check --all-targets` catches any use
+        # of a newer-than-1.85 API across lib + tests without a heavy build.
+        run: |
+          rustup toolchain install 1.85 --profile minimal
+          cargo +1.85 check --all-targets --features "cachekitio,redis,encryption,l1,macros"
 
       - name: Publish cachekit-macros to crates.io
         run: cargo publish -p cachekit-macros


### PR DESCRIPTION
## Summary

Fixes the 6+ day red `1.85` (MSRV) CI job on `main`. **It is not a code or MSRV bug** — the crate compiles and tests clean on rustc 1.85.1 locally, and the committed `Cargo.lock` builds on 1.85.

The runner is being **OOM-killed**. The `cachekit-lean` ARC pod has a hard **6Gi memory cgroup** (lab ADR-0001) and no build cache, so the `1.85` job runs a fully **cold** `cargo test` build of the 246-crate async/TLS/crypto graph. `cargo` defaults `-j` to the visible core count (**~24** via the pod CPU limit), and at that fan-out the cold build's peak RSS — dominated by full test-profile **debuginfo at link time** — exceeds 6Gi. The kernel OOM-kills the linker, the runner "loses communication with the server," and the job fails at the **~10-minute heartbeat reckoning** with no logs uploaded (the `BlobNotFound` symptom).

`stable`/`beta` pass because their preceding **clippy** step pre-builds the dependency graph, lowering the `test` step's peak. The `1.85` job skips clippy, concentrating the whole cold build into one step.

## Evidence

- Job annotation (survives the lost log blob): *"The self-hosted runner lost communication with the server… terminates the runner process, **starves it for CPU/Memory**, or blocks its network access."*
- Step timeline: `Run tests` frozen `in_progress`, no `Complete job`, job failed at a clean ~10-min mark → killed mid-step, not a test failure.
- **Empirical repro:** a cold `cargo test --no-run -j24` inside a 6Gi no-swap cgroup is OOM-killed during the `cachekit-rs` test-binary link —
  `kernel: Memory cgroup out of memory: Killed process … (ld)` / `scope: Failed with result 'oom-kill'`.
- Non-deterministic across re-runs (passed once, failed twice) — the signature of a resource-edge, not a deterministic code bug.

## Changes

- **`ci.yml`** — `CARGO_BUILD_JOBS=4` caps concurrent compile/link jobs so peak RSS stays well under 6Gi on the cache-less lean pod (the ~6× reduction in the fan-out is the fix).
- **`ci.yml`** — `timeout-minutes` on `test` (20) and `wasm` (15) so a wedged runner fails fast instead of hanging to the heartbeat timeout.
- **`release.yml`** — same `CARGO_BUILD_JOBS` cap on the `publish` job (also runs on `cachekit-lean`), plus a **1.85 MSRV compile check before publish** so a broken floor can't ship silently — `release` previously built `stable` only, which is how 0.3.0 published while the MSRV job was red.

MSRV floor stays at **1.85** (deliberate, edition2024 — not bumped; bumping `-j` value, not the toolchain, is the fix).

## Validation

The `1.85` job on this PR runs at `-j4` on `cachekit-lean` — green here proves the fix in the real constrained environment. If it proves marginal at the link spike, the `CARGO_BUILD_JOBS` value will be lowered.

> Note: the broken ARC log persistence (`BlobNotFound`) is a separate runner-side observability defect tracked outside this repo; preventing the OOM is what makes the job pass.

Closes #25


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved build stability and release pipeline reliability through enhanced resource management and validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->