### PR TITLE
ci: cap cargo build parallelism to fit 6Gi runner (fixes 1.85 OOM)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ env:
   # cross-device link errors on container overlay filesystems.
   RUSTUP_HOME: /tmp/rustup
   CARGO_HOME: /tmp/cargo
+  # cargo reads the node's CPU count (32t), not the pod's cgroup quota, so it
+  # spawns ~32 parallel rustc in a 6Gi runner and OOM-kills the build (SIGKILL
+  # 137) mid-`cargo test`. Cap parallelism to fit the memory ceiling.
+  CARGO_BUILD_JOBS: "4"
 
 jobs:
   test:


### PR DESCRIPTION
Fixes the 6-day red CI on `main` (#25).

## Root cause (diagnosed live on the ARC runner)

The `1.85` matrix job was killed (SIGKILL/137) ~10 min into `cargo test`, in the test step, with no step conclusion — and the runner died before it could upload its log blob, which is why GitHub returned `BlobNotFound` and the failure was undiagnosable from the UI.

**cargo reads the node's CPU count (32 threads), not the pod's cgroup CPU quota**, so it spawned ~32 parallel `rustc` in the 6Gi `cachekit-lean` runner. The build's memory peak (codegen/link) blew the 6Gi ceiling → cgroup memory pressure → thrash for ~10 min → OOM-kill.

Why only `1.85`: `stable`/`beta` run `clippy` first (warming build artifacts), so their `cargo test` is incremental and lower-peak. `1.85` skips fmt/clippy and does the full cold 32-way compile in one step → hits the ceiling.

## Fix + proof

Cap `CARGO_BUILD_JOBS: "4"` so peak memory fits the 6Gi limit. Result on this branch:

| | before | after (capped) |
|---|---|---|
| 1.85 | ❌ killed at ~10:00 (137) | ✅ **75s** |
| stable / beta / wasm | ✅ | ✅ |

The build doesn't just survive — it's an order of magnitude faster, because it's no longer thrashing under memory pressure.

## Note
A more principled fix is making cargo honor the cgroup CPU quota (derive `-j` from the request), but the env cap is the pragmatic, proven fix. The same footgun likely affects other cachekit Rust repos on these runners (e.g. cachekit-core).