### PR TITLE
security: send lock_id via X-CacheKit-Lock-Id header, not query string (#24)

### DIFF
--- a/crates/cachekit/src/backend/cachekitio_lock.rs
+++ b/crates/cachekit/src/backend/cachekitio_lock.rs
@@ -7,6 +7,30 @@ use super::cachekitio::{reqwest_err_sanitized, CachekitIO};
 use super::LockableBackend;
 use crate::error::BackendError;
 
+/// Lock capability token travels in this request header, never the query string
+/// (CWE-532): a `?lock_id=` query leaks the token into access/proxy logs and
+/// OpenTelemetry `http.url` spans. SaaS dual-reads header + legacy query during
+/// rollout, preferring the header. See protocol `spec/saas-api.md`.
+const LOCK_ID_HEADER: &str = "X-CacheKit-Lock-Id";
+
+impl CachekitIO {
+    /// Build the unlock request. Extracted so tests can assert the lock_id rides the
+    /// `X-CacheKit-Lock-Id` header and never appears in the URL (CWE-532).
+    fn release_request(&self, key: &str, lock_id: &str) -> reqwest::RequestBuilder {
+        let url = format!(
+            "{}/v1/cache/{}/lock",
+            self.api_url(),
+            urlencoding::encode(key)
+        );
+        self.with_standard_headers(
+            self.client()
+                .delete(&url)
+                .bearer_auth(self.api_key_str())
+                .header(LOCK_ID_HEADER, lock_id),
+        )
+    }
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct LockAcquireRequest {
@@ -64,17 +88,10 @@ impl LockableBackend for CachekitIO {
     }
 
     async fn release_lock(&self, key: &str, lock_id: &str) -> Result<bool, BackendError> {
-        let url = format!(
-            "{}/v1/cache/{}/lock?lock_id={}",
-            self.api_url(),
-            urlencoding::encode(key),
-            urlencoding::encode(lock_id),
-        );
-
-        let req =
-            self.with_standard_headers(self.client().delete(&url).bearer_auth(self.api_key_str()));
-
-        let resp = req
+        // lock_id is a capability token → X-CacheKit-Lock-Id header, not the query string
+        // (CWE-532). See `release_request`.
+        let resp = self
+            .release_request(key, lock_id)
             .send()
             .await
             .map_err(|e| reqwest_err_sanitized(e, self.api_key_str()))?;
@@ -99,5 +116,39 @@ mod tests {
         fn _check(backend: &CachekitIO) {
             _assert_lockable(backend);
         }
+    }
+
+    #[test]
+    #[allow(clippy::expect_used)] // test-only: a failed build/missing header should panic loudly
+    fn release_lock_sends_token_in_header_not_url() {
+        let backend = CachekitIO::builder()
+            .api_url("https://api.cachekit.io")
+            .api_key("ck_test_key")
+            .build()
+            .expect("builder should succeed for the canonical host");
+
+        let req = backend
+            .release_request("my-key", "lock-secret-123")
+            .build()
+            .expect("request should build");
+
+        // CWE-532: the capability token must never appear in the URL.
+        let url = req.url();
+        assert!(url.query().is_none(), "unexpected query string: {url}");
+        assert!(
+            !url.as_str().contains("lock_id"),
+            "lock_id leaked into URL: {url}"
+        );
+        assert!(
+            !url.as_str().contains("lock-secret-123"),
+            "token leaked into URL: {url}"
+        );
+
+        // ...it rides the X-CacheKit-Lock-Id header under the exact wire name.
+        let header = req
+            .headers()
+            .get("X-CacheKit-Lock-Id")
+            .expect("X-CacheKit-Lock-Id header must be set");
+        assert_eq!(header, "lock-secret-123");
     }
 }


### PR DESCRIPTION
Closes #24.

`release_lock` built the unlock URL as `{key}/lock?lock_id={token}`. Query strings leak into access/proxy logs and OpenTelemetry `http.url` spans (**CWE-532**) — even URL-encoded, the capability token is still *in the URL* and replayable within the lock TTL.

## Change
- Extracted `CachekitIO::release_request()` (shared by `release_lock` and a server-free test).
- Dropped `?lock_id=` from the URL; the token is sent in the **`X-CacheKit-Lock-Id`** header (new `LOCK_ID_HEADER` const).

## Wire compatibility
SaaS dual-reads the header + legacy `?lock_id=` (prefers header), shipped in **saas#140 / deployed in `0.1.7`**. Wire-compatible with live `api.cachekit.io`. Ratified in protocol `spec/saas-api.md`.

## Tests / checks
- New unit test builds the request via `RequestBuilder::build()` (no mock server) and asserts the token is in the header and **never** in the DELETE URL (no query, no `lock_id`, no token substring).
- `cargo test` + `cargo clippy --all-targets -- -D warnings` + `cargo fmt --check` all clean.
- **Audited** `crates/cachekit/src/backend/workers.rs` (per #24) — no `lock_id` query usage there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced security for lock token transmission in the cachekit.io backend. Lock capability tokens are now transmitted through secure HTTP request headers instead of being appended to URL query parameters. This improves the overall security and reliability of distributed lock operations whilst maintaining full backward compatibility with existing functionality and integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->