### PR TITLE
chore: bump crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
[RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204): invalid pointer dereference in `fmt::Pointer` impl for `Atomic`/`Shared` in crossbeam-epoch 0.9.18. Published after our last release — will fail the next security gate run here, as it already did on cachekit-py (see cachekit-io/cachekit-py#208 for the full sweep context).

One-line `cargo update -p crossbeam-epoch` → 0.9.20. Dev-only chain (criterion → rayon → crossbeam-deque).

Verified locally in a clean worktree: `cargo deny --all-features check` — advisories ok, bans ok, licenses ok, sources ok.