### PR TITLE
ci: assign 27Bslash6 on release-please release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,19 @@ jobs:
       - name: Debug release-please outputs
         run: echo '${{ toJSON(steps.release.outputs) }}'
 
+      - name: Assign release PR to 27Bslash6
+        # REST instead of `gh pr edit --add-assignee`: gh's assignee edit goes
+        # through GraphQL mutations that 403 with app installation tokens
+        # (cli/cli#6274, replaceActorsForAssignable). The assignees REST
+        # endpoint works with the PR-write permission the app token has.
+        if: ${{ steps.release.outputs.pr }}
+        run: |
+          gh api -X POST \
+            "repos/${{ github.repository }}/issues/${{ fromJson(steps.release.outputs.pr).number }}/assignees" \
+            -f "assignees[]=27Bslash6"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
   publish:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}


### PR DESCRIPTION
Closes LAB-151 (parent LAB-146): notify `27Bslash6` on every release-please release PR in cachekit-rs.

## What

Adds one guarded step to `.github/workflows/release.yml` after the release-please step:

- `if: ${{ steps.release.outputs.pr }}` — the `pr` output is a JSON `PullRequest` string, **unset** when no release PR was created/updated (verified against the README at the pinned action SHA), so the step is a no-op on ordinary pushes to main.
- Assigns `27Bslash6` via `POST /repos/{repo}/issues/{number}/assignees` using the existing GitHub App token.

The release-please step already had `id: release`, so no other changes were needed.

## Why REST instead of `gh pr edit --add-assignee`

The issue's acceptance criteria suggest `gh pr edit`, but gh's assignee edits go through GraphQL mutations with documented failures under app installation tokens:

- [cli/cli#6274](https://github.com/cli/cli/issues/6274) — `gh pr edit` requires `repository-projects: read` that integration tokens can't always get
- the newer `replaceActorsForAssignable` mutation 403s ("Resource not accessible by integration") for app tokens

The REST assignees endpoint needs only the PR-write permission the app token demonstrably has (release-please labels its PRs with it). Same outcome, none of the landmines.

## Monorepo note

`release-please-config.json` has no `separate-pull-requests` and uses the `linked-versions` plugin grouping both crates, so release-please opens **one** combined release PR — `outputs.pr` (first PR) covers it.

## Verification

- actionlint clean on the change (only pre-existing finding: custom runner label `cachekit-lean` in the untouched publish job).
- True end-to-end verification requires merge: the workflow only triggers on push to `main`. The next release-worthy commit should produce a `chore(main): release …` PR with `27Bslash6` assigned; the step's failure mode is loud (non-2xx fails the job), not silent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated release pull requests are now assigned to the designated release maintainer when created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->